### PR TITLE
ci: trigger PyPI publish from version tags

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,9 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- trigger PyPI publishing on pushes of version tags (*)
- keep trusted publishing via the elease environment
- align release flow so package publication depends on tag creation by a maintainer

## Why
This removes package publication from GitHub Release publication and ties it to maintainer-controlled tag creation instead.