### PR TITLE
chore: bump version to 1.2.2

### DIFF
--- a/codehealthanalyzer/version.py
+++ b/codehealthanalyzer/version.py
@@ -1,3 +1,3 @@
 """Versionamento central do pacote."""
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"


### PR DESCRIPTION
## Summary
- bump package version from 1.2.1 to 1.2.2

## Why
- create a fresh version to test the automated PyPI publish flow triggered by version tags