### PR TITLE
ci: clean up PyPI publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will upload a Python Package to PyPI when a release is created
+# This workflow uploads a Python package to PyPI when a version tag is pushed.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
 # This workflow uses actions that are not certified by GitHub.
@@ -15,6 +15,9 @@ on:
 
 permissions:
   contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release-build:


### PR DESCRIPTION
## Summary
- update the workflow header comment to match the current tag-based trigger
- opt JavaScript actions into Node 24 in this workflow to reduce deprecation noise

## Why
The workflow is already correct functionally, but its metadata and runtime warnings were stale.