### PR TITLE
fix: support UTF-8 BOM in violations analyzer

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will upload a Python Package to PyPI when a release is created
+# This workflow uploads a Python package to PyPI when a version tag is pushed.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
 # This workflow uses actions that are not certified by GitHub.
@@ -15,6 +15,9 @@ on:
 
 permissions:
   contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   release-build:

--- a/codehealthanalyzer/analyzers/violations.py
+++ b/codehealthanalyzer/analyzers/violations.py
@@ -121,7 +121,7 @@ class ViolationsAnalyzer(BaseAnalyzer):
         doc_lines = self._python_docstring_lines(tree)
         count = 0
         try:
-            with open(file_path, "r", encoding="utf-8") as fh:
+            with open(file_path, "r", encoding="utf-8-sig") as fh:
                 for idx, raw in enumerate(fh, 1):
                     stripped = raw.strip()
                     if not stripped or stripped.startswith("#"):
@@ -150,7 +150,7 @@ class ViolationsAnalyzer(BaseAnalyzer):
 
     def _count_html_lines(self, file_path: Path) -> int:
         try:
-            with open(file_path, "r", encoding="utf-8") as fh:
+            with open(file_path, "r", encoding="utf-8-sig") as fh:
                 return sum(1 for line in fh if line.strip())
         except OSError as exc:
             logger.warning("Falha ao ler template %s: %s", file_path, exc)
@@ -192,7 +192,7 @@ class ViolationsAnalyzer(BaseAnalyzer):
         if file_path.suffix == ".py":
             result["type"] = "Python"
             try:
-                with open(file_path, "r", encoding="utf-8") as fh:
+                with open(file_path, "r", encoding="utf-8-sig") as fh:
                     source = fh.read()
                 tree = ast.parse(source, filename=str(file_path))
             except (OSError, SyntaxError) as exc:

--- a/tests/test_violations_analyzer.py
+++ b/tests/test_violations_analyzer.py
@@ -71,6 +71,18 @@ def test_check_file_python_syntax_error(tmp_path):
     assert len(result["violations"]) > 0
 
 
+def test_check_file_python_with_utf8_bom(tmp_path):
+    f = tmp_path / "bom_module.py"
+    f.write_text("x = 1\n", encoding="utf-8-sig")
+
+    result = _make(tmp_path, {"no_default_excludes": True}).check_file(f)
+
+    assert result["violations"] == []
+    assert result["priority"] == "low"
+    assert result["type"] == "Python"
+    assert result["lines"] == 1
+
+
 # ---------------------------------------------------------------------------
 # check_file — HTML
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- read analyzed source files with `utf-8-sig` in the violations analyzer
- add a regression test for Python files saved with UTF-8 BOM

## Why
Some external repositories contain `.py` files with UTF-8 BOM at byte zero. Using plain `utf-8` caused `ast.parse` to fail with `invalid non-printable character U+FEFF`.
