### PR TITLE
feat: add detail modes for analyze JSON output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[web]
-          pip install pytest pytest-cov pytest-mock
+          pip install pytest pytest-cov pytest-mock httpx
 
       - name: Lint (ruff)
         if: matrix.python-version == '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,25 +25,32 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[dev,web]
+          pip install -e .[web]
+          pip install pytest pytest-cov pytest-mock
 
       - name: Lint (ruff)
+        if: matrix.python-version == '3.12'
         run: |
+          pip install black isort bandit mypy
           ruff --version
           ruff check codehealthanalyzer
       - name: Format check (black)
+        if: matrix.python-version == '3.12'
         run: |
           black --version
           black --check codehealthanalyzer
       - name: Import order check (isort)
+        if: matrix.python-version == '3.12'
         run: |
           isort --version-number
           isort --profile black --check-only codehealthanalyzer
       - name: Security scan (bandit)
+        if: matrix.python-version == '3.12'
         run: |
           bandit -q -r codehealthanalyzer
 
       - name: Type check (mypy)
+        if: matrix.python-version == '3.12'
         continue-on-error: true
         run: |
           mypy codehealthanalyzer --ignore-missing-imports

--- a/codehealthanalyzer/cli/main.py
+++ b/codehealthanalyzer/cli/main.py
@@ -264,10 +264,11 @@ def _build_standard_report(report: FullReport) -> dict[str, Any]:
     templates = report.get("templates", {})
     errors = report.get("errors", {})
 
-    violation_items = cast(list[dict[str, Any]], violations.get("violations", []) or [])
-    warning_items = cast(list[dict[str, Any]], violations.get("warnings", []) or [])
-    template_items = cast(list[dict[str, Any]], templates.get("templates", []) or [])
-    error_items = cast(list[dict[str, Any]], errors.get("errors", []) or [])
+    # Compatibilidade com Python 3.8: evitar generics PEP585 em runtime dentro de cast().
+    violation_items = cast(list, violations.get("violations", []) or [])
+    warning_items = cast(list, violations.get("warnings", []) or [])
+    template_items = cast(list, templates.get("templates", []) or [])
+    error_items = cast(list, errors.get("errors", []) or [])
 
     return {
         "metadata": report.get("metadata", {}),

--- a/codehealthanalyzer/cli/main.py
+++ b/codehealthanalyzer/cli/main.py
@@ -129,11 +129,31 @@ def _write_report_files(
     base_name: str,
     format_name: str,
     no_json: bool,
+    detail: str = "full",
 ) -> None:
     formatter = ReportFormatter()
     output_path.mkdir(parents=True, exist_ok=True)
+
     if not no_json:
-        formatter.to_json(report, str(output_path / f"{base_name}.json"))
+        summary_report = _build_summary_report(report)
+        if detail == "summary":
+            formatter.to_json(summary_report, str(output_path / f"{base_name}.json"))
+            formatter.to_json(
+                summary_report, str(output_path / f"{base_name}.summary.json")
+            )
+        elif detail == "standard":
+            formatter.to_json(
+                _build_standard_report(report), str(output_path / f"{base_name}.json")
+            )
+            formatter.to_json(
+                summary_report, str(output_path / f"{base_name}.summary.json")
+            )
+        else:
+            formatter.to_json(report, str(output_path / f"{base_name}.json"))
+            formatter.to_json(report, str(output_path / f"{base_name}.full.json"))
+            formatter.to_json(
+                summary_report, str(output_path / f"{base_name}.summary.json")
+            )
     if format_name in ["html", "all"]:
         ReportGenerator().generate_html_report(
             report, str(output_path / f"{base_name}.html")
@@ -142,6 +162,107 @@ def _write_report_files(
         formatter.to_markdown(report, str(output_path / f"{base_name}.md"))
     if format_name in ["csv", "all"]:
         formatter.to_csv(report, str(output_path / f"{base_name}.csv"))
+
+
+def _build_summary_report(report: FullReport, top_n: int = 10) -> dict[str, Any]:
+    violations = report.get("violations", {})
+    templates = report.get("templates", {})
+    errors = report.get("errors", {})
+    return {
+        "metadata": report.get("metadata", {}),
+        "summary": report.get("summary", {}),
+        "priorities": report.get("priorities", []),
+        "top_violations": (violations.get("violations", []) or [])[:top_n],
+        "top_warnings": (violations.get("warnings", []) or [])[:top_n],
+        "top_templates": (templates.get("templates", []) or [])[:top_n],
+        "top_errors": (errors.get("errors", []) or [])[:top_n],
+    }
+
+
+def _standardize_violation_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in items:
+        messages = item.get("violations", []) or []
+        out.append(
+            {
+                "file": item.get("file", ""),
+                "type": item.get("type", ""),
+                "lines": item.get("lines", 0),
+                "priority": item.get("priority", "low"),
+                "violation_count": len(messages),
+                "sample_violations": messages[:5],
+            }
+        )
+    return out
+
+
+def _standardize_templates(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in items:
+        out.append(
+            {
+                "file": item.get("file", ""),
+                "priority": item.get("priority", "low"),
+                "category": item.get("category", ""),
+                "total_css_chars": item.get("total_css_chars", item.get("css", 0)),
+                "total_js_chars": item.get("total_js_chars", item.get("js", 0)),
+                "css_inline_count": len(item.get("css_inline", []) or []),
+                "css_style_tags_count": len(item.get("css_style_tags", []) or []),
+                "js_inline_count": len(item.get("js_inline", []) or []),
+                "js_script_tags_count": len(item.get("js_script_tags", []) or []),
+            }
+        )
+    return out
+
+
+def _standardize_errors(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in items:
+        details = item.get("errors", []) or []
+        out.append(
+            {
+                "file": item.get("file", ""),
+                "priority": item.get("priority", "low"),
+                "category": item.get("category", ""),
+                "error_count": item.get("error_count", len(details)),
+                "sample_errors": details[:5],
+            }
+        )
+    return out
+
+
+def _build_standard_report(report: FullReport) -> dict[str, Any]:
+    violations = report.get("violations", {})
+    templates = report.get("templates", {})
+    errors = report.get("errors", {})
+
+    violation_items = cast(list[dict[str, Any]], violations.get("violations", []) or [])
+    warning_items = cast(list[dict[str, Any]], violations.get("warnings", []) or [])
+    template_items = cast(list[dict[str, Any]], templates.get("templates", []) or [])
+    error_items = cast(list[dict[str, Any]], errors.get("errors", []) or [])
+
+    return {
+        "metadata": report.get("metadata", {}),
+        "summary": report.get("summary", {}),
+        "quality_score": report.get("quality_score", 0),
+        "priorities": report.get("priorities", []),
+        "violations": {
+            "metadata": violations.get("metadata", {}),
+            "statistics": violations.get("statistics", {}),
+            "violations": _standardize_violation_items(violation_items),
+            "warnings": _standardize_violation_items(warning_items),
+        },
+        "templates": {
+            "metadata": templates.get("metadata", {}),
+            "statistics": templates.get("statistics", {}),
+            "templates": _standardize_templates(template_items),
+        },
+        "errors": {
+            "metadata": errors.get("metadata", {}),
+            "statistics": errors.get("statistics", {}),
+            "errors": _standardize_errors(error_items),
+        },
+    }
 
 
 @click.group()
@@ -178,6 +299,13 @@ def cli():
 )
 @click.option("--no-json", is_flag=True, help="Não gerar o relatório JSON padrão")
 @click.option(
+    "--detail",
+    type=click.Choice(["summary", "standard", "full"]),
+    default="standard",
+    show_default=True,
+    help="Nível de detalhe do JSON gerado",
+)
+@click.option(
     "--config", "-c", type=click.Path(exists=True), help="Arquivo de configuração JSON"
 )
 @click.option(
@@ -191,6 +319,7 @@ def analyze(
     output: Optional[str],
     format: str,
     no_json: bool,
+    detail: str,
     config: Optional[str],
     no_default_excludes: bool,
     verbose: bool,
@@ -274,7 +403,14 @@ def analyze(
 
         # Diretório de saída padrão
         output_path = Path(output or "reports")
-        _write_report_files(report, output_path, "full_report", format, no_json)
+        _write_report_files(
+            report,
+            output_path,
+            "full_report",
+            format,
+            no_json,
+            detail=detail,
+        )
 
         click.echo("\n" + ColorHelper.success("Análise concluída com sucesso!"))
 

--- a/codehealthanalyzer/cli/main.py
+++ b/codehealthanalyzer/cli/main.py
@@ -164,6 +164,28 @@ def _write_report_files(
         formatter.to_csv(report, str(output_path / f"{base_name}.csv"))
 
 
+def _write_analyze_json_files(
+    report: FullReport,
+    output_path: Path,
+    detail: str,
+) -> None:
+    formatter = ReportFormatter()
+    summary_report = _build_summary_report(report)
+
+    # Arquivos base amigaveis para consumo humano e integracoes simples.
+    formatter.to_json(summary_report, str(output_path / "summary_report.json"))
+    formatter.to_json(report.get("violations", {}), str(output_path / "violations_report.json"))
+    formatter.to_json(report.get("templates", {}), str(output_path / "templates_report.json"))
+    formatter.to_json(report.get("errors", {}), str(output_path / "errors_report.json"))
+
+    if detail in ["standard", "full"]:
+        formatter.to_json(_build_standard_report(report), str(output_path / "analysis_report.json"))
+
+    # Relatorio completo agora e opcional e so e gerado explicitamente.
+    if detail == "full":
+        formatter.to_json(report, str(output_path / "full_report.json"))
+
+
 def _build_summary_report(report: FullReport, top_n: int = 10) -> dict[str, Any]:
     violations = report.get("violations", {})
     templates = report.get("templates", {})
@@ -303,7 +325,7 @@ def cli():
     type=click.Choice(["summary", "standard", "full"]),
     default="standard",
     show_default=True,
-    help="Nível de detalhe do JSON gerado",
+    help="Nível de detalhe (full_report.json é gerado apenas em 'full')",
 )
 @click.option(
     "--config", "-c", type=click.Path(exists=True), help="Arquivo de configuração JSON"
@@ -403,13 +425,11 @@ def analyze(
 
         # Diretório de saída padrão
         output_path = Path(output or "reports")
+        output_path.mkdir(parents=True, exist_ok=True)
+        if not no_json:
+            _write_analyze_json_files(report, output_path, detail)
         _write_report_files(
-            report,
-            output_path,
-            "full_report",
-            format,
-            no_json,
-            detail=detail,
+            report, output_path, "analysis_report", format, no_json=True, detail=detail
         )
 
         click.echo("\n" + ColorHelper.success("Análise concluída com sucesso!"))

--- a/codehealthanalyzer/cli/main.py
+++ b/codehealthanalyzer/cli/main.py
@@ -174,12 +174,18 @@ def _write_analyze_json_files(
 
     # Arquivos base amigaveis para consumo humano e integracoes simples.
     formatter.to_json(summary_report, str(output_path / "summary_report.json"))
-    formatter.to_json(report.get("violations", {}), str(output_path / "violations_report.json"))
-    formatter.to_json(report.get("templates", {}), str(output_path / "templates_report.json"))
+    formatter.to_json(
+        report.get("violations", {}), str(output_path / "violations_report.json")
+    )
+    formatter.to_json(
+        report.get("templates", {}), str(output_path / "templates_report.json")
+    )
     formatter.to_json(report.get("errors", {}), str(output_path / "errors_report.json"))
 
     if detail in ["standard", "full"]:
-        formatter.to_json(_build_standard_report(report), str(output_path / "analysis_report.json"))
+        formatter.to_json(
+            _build_standard_report(report), str(output_path / "analysis_report.json")
+        )
 
     # Relatorio completo agora e opcional e so e gerado explicitamente.
     if detail == "full":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -60,7 +60,12 @@ def test_analyze_runs_on_valid_project(runner, project, tmp_path):
             ["analyze", str(project), "--output", str(out), "--no-default-excludes"],
         )
     assert result.exit_code == 0
-    assert (out / "full_report.json").exists()
+    assert (out / "summary_report.json").exists()
+    assert (out / "analysis_report.json").exists()
+    assert (out / "violations_report.json").exists()
+    assert (out / "templates_report.json").exists()
+    assert (out / "errors_report.json").exists()
+    assert not (out / "full_report.json").exists()
 
 
 def test_analyze_json_report_has_summary(runner, project, tmp_path):
@@ -70,7 +75,7 @@ def test_analyze_json_report_has_summary(runner, project, tmp_path):
             cli,
             ["analyze", str(project), "--output", str(out), "--no-default-excludes"],
         )
-    report = json.loads((out / "full_report.json").read_text(encoding="utf-8"))
+    report = json.loads((out / "summary_report.json").read_text(encoding="utf-8"))
     assert "summary" in report
     assert "quality_score" in report["summary"]
 
@@ -100,7 +105,7 @@ def test_analyze_markdown_format(runner, project, tmp_path):
                 "--no-default-excludes",
             ],
         )
-    assert (out / "full_report.md").exists()
+    assert (out / "analysis_report.md").exists()
 
 
 def test_analyze_no_json_flag(runner, project, tmp_path):
@@ -117,7 +122,11 @@ def test_analyze_no_json_flag(runner, project, tmp_path):
                 "--no-default-excludes",
             ],
         )
-    assert not (out / "full_report.json").exists()
+    assert not (out / "summary_report.json").exists()
+    assert not (out / "analysis_report.json").exists()
+    assert not (out / "violations_report.json").exists()
+    assert not (out / "templates_report.json").exists()
+    assert not (out / "errors_report.json").exists()
 
 
 def test_analyze_detail_summary_generates_summary_files(runner, project, tmp_path):
@@ -136,9 +145,13 @@ def test_analyze_detail_summary_generates_summary_files(runner, project, tmp_pat
             ],
         )
 
-    assert (out / "full_report.json").exists()
-    assert (out / "full_report.summary.json").exists()
-    data = json.loads((out / "full_report.json").read_text(encoding="utf-8"))
+    assert (out / "summary_report.json").exists()
+    assert (out / "violations_report.json").exists()
+    assert (out / "templates_report.json").exists()
+    assert (out / "errors_report.json").exists()
+    assert not (out / "analysis_report.json").exists()
+    assert not (out / "full_report.json").exists()
+    data = json.loads((out / "summary_report.json").read_text(encoding="utf-8"))
     assert "summary" in data
     assert "top_violations" in data
 
@@ -159,9 +172,12 @@ def test_analyze_detail_full_generates_full_alias_file(runner, project, tmp_path
             ],
         )
 
+    assert (out / "summary_report.json").exists()
+    assert (out / "analysis_report.json").exists()
+    assert (out / "violations_report.json").exists()
+    assert (out / "templates_report.json").exists()
+    assert (out / "errors_report.json").exists()
     assert (out / "full_report.json").exists()
-    assert (out / "full_report.full.json").exists()
-    assert (out / "full_report.summary.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,50 @@ def test_analyze_no_json_flag(runner, project, tmp_path):
     assert not (out / "full_report.json").exists()
 
 
+def test_analyze_detail_summary_generates_summary_files(runner, project, tmp_path):
+    out = tmp_path / "out"
+    with patch("shutil.which", return_value=None):
+        runner.invoke(
+            cli,
+            [
+                "analyze",
+                str(project),
+                "--output",
+                str(out),
+                "--detail",
+                "summary",
+                "--no-default-excludes",
+            ],
+        )
+
+    assert (out / "full_report.json").exists()
+    assert (out / "full_report.summary.json").exists()
+    data = json.loads((out / "full_report.json").read_text(encoding="utf-8"))
+    assert "summary" in data
+    assert "top_violations" in data
+
+
+def test_analyze_detail_full_generates_full_alias_file(runner, project, tmp_path):
+    out = tmp_path / "out"
+    with patch("shutil.which", return_value=None):
+        runner.invoke(
+            cli,
+            [
+                "analyze",
+                str(project),
+                "--output",
+                str(out),
+                "--detail",
+                "full",
+                "--no-default-excludes",
+            ],
+        )
+
+    assert (out / "full_report.json").exists()
+    assert (out / "full_report.full.json").exists()
+    assert (out / "full_report.summary.json").exists()
+
+
 # ---------------------------------------------------------------------------
 # violations
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -35,7 +35,7 @@ def test_cli_analyze_generates_json_report(tmp_path):
     )
 
     assert proc.returncode == 0
-    report_file = output_dir / "full_report.json"
+    report_file = output_dir / "summary_report.json"
     assert report_file.exists()
     report = json.loads(report_file.read_text(encoding="utf-8"))
     assert "summary" in report


### PR DESCRIPTION
## Summary
- add `--detail` to `analyze` with modes: `summary`, `standard`, `full`
- default JSON output now uses `standard` detail to reduce report size
- add dedicated summary/full JSON artifacts for easier consumption
- add CLI tests for new detail modes

## Why
Large full reports are hard to consume manually. These modes preserve automation support while producing much more user-friendly default JSON output.
