### PR TITLE
chore: bump version to 1.2.4 on master

### DIFF
--- a/codehealthanalyzer/version.py
+++ b/codehealthanalyzer/version.py
@@ -1,3 +1,3 @@
 """Versionamento central do pacote."""
 
-__version__ = "1.2.2"
+__version__ = "1.2.4"


### PR DESCRIPTION
Bump package version on the protected default branch so we can tag and publish from `master`.

- updates `codehealthanalyzer/version.py` from `1.2.2` to `1.2.4`
- no functional code changes