### PR TITLE
docs: prioritize `cha` command in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,26 @@ No comando `analyze`, o JSON completo agora é opcional:
 - `--detail standard` (padrão): idem + `analysis_report.json`
 - `--detail full`: idem + `full_report.json`
 
+Arquivos gerados por modo:
+
+- `summary`: `summary_report.json`, `violations_report.json`, `templates_report.json`, `errors_report.json`
+- `standard`: todos do `summary` + `analysis_report.json`
+- `full`: todos do `standard` + `full_report.json`
+
 Exemplos:
 
 ```bash
 cha analyze . --config cha_config.json --detail summary
 cha analyze . --detail full --format all --output reports
 ```
+
+## Troubleshooting
+
+`Error: Invalid value for '--config' ... Path 'cha_config.json' does not exist`
+- Crie o arquivo no diretório atual, ou passe caminho absoluto em `--config`.
+
+`WARNING: Ignoring invalid distribution ~odehealthanalyzer`
+- É lixo de instalação antiga no `site-packages`; remova diretórios `~odehealthanalyzer*`.
 
 ## Contrato de relatório
 

--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ pip install -e ".[dev,web]"
 
 ### CLI
 
+Use `cha` como comando recomendado (alias curto de `codehealthanalyzer`).
+
 ```bash
-codehealthanalyzer analyze .
-codehealthanalyzer analyze . --format all --output reports
-codehealthanalyzer violations . --format csv
-codehealthanalyzer templates . --config config.json
-codehealthanalyzer errors . --no-json --format markdown
-codehealthanalyzer dashboard .
+cha analyze .
+cha analyze . --format all --output reports
+cha violations . --format csv
+cha templates . --config cha_config.json
+cha errors . --no-json --format markdown
+cha dashboard .
 ```
 
 ### API Python
@@ -57,7 +59,7 @@ print(report["summary"]["quality_score"])
 
 ## Configuração
 
-Exemplo de `config.json`:
+Exemplo de `cha_config.json`:
 
 ```json
 {
@@ -76,14 +78,57 @@ Exemplo de `config.json`:
 }
 ```
 
-Campos suportados:
+### Ordem de precedência
 
-- `limits`: sobrescreve limites de tamanho
-- `target_dir`: diretório analisado pelo Ruff
-- `templates_dir`: string ou lista de diretórios de templates
-- `exclude_dirs`: string ou lista de diretórios extras a ignorar
-- `ruff_fix`: roda `ruff check --fix` antes da coleta
-- `no_default_excludes`: desabilita as exclusões padrão
+- Flags da CLI (maior prioridade)
+- Arquivo `--config`
+- Defaults da biblioteca
+
+### Campos suportados
+
+| Campo | Tipo | Padrão | O que controla |
+|---|---|---|---|
+| `limits` | objeto | limites internos | Limites de tamanho por tipo de arquivo/estrutura |
+| `target_dir` | string | `"."` | Diretório alvo para análise de código (incluindo Ruff) |
+| `templates_dir` | string ou lista | autodetecção | Diretórios HTML/Jinja a varrer |
+| `exclude_dirs` | string ou lista | `[]` | Exclusões adicionais além das exclusões padrão |
+| `ruff_fix` | boolean | `false` | Executa `ruff check --fix` antes da coleta de erros |
+| `no_default_excludes` | boolean | `false` | Remove exclusões padrão (`tests`, `venv`, `dist`, etc.) |
+
+### Configurações rápidas por cenário
+
+Projeto Flask/Django com templates em múltiplas pastas:
+
+```json
+{
+  "templates_dir": ["templates", "app/templates", "src/templates"],
+  "exclude_dirs": ["migrations", "node_modules"]
+}
+```
+
+Monorepo (analisar apenas um subprojeto):
+
+```json
+{
+  "target_dir": "services/billing",
+  "templates_dir": ["services/billing/templates"]
+}
+```
+
+### Controle de detalhamento dos relatórios
+
+No comando `analyze`, o JSON completo agora é opcional:
+
+- `--detail summary`: gera resumo + arquivos por domínio (`violations/templates/errors`)
+- `--detail standard` (padrão): idem + `analysis_report.json`
+- `--detail full`: idem + `full_report.json`
+
+Exemplos:
+
+```bash
+cha analyze . --config cha_config.json --detail summary
+cha analyze . --detail full --format all --output reports
+```
 
 ## Contrato de relatório
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -36,13 +36,15 @@ pip install -e ".[dev,web]"
 
 ### CLI
 
+Use `cha` as the recommended command (short alias for `codehealthanalyzer`).
+
 ```bash
-codehealthanalyzer analyze .
-codehealthanalyzer analyze . --format all --output reports
-codehealthanalyzer violations . --format csv
-codehealthanalyzer templates . --config config.json
-codehealthanalyzer errors . --no-json --format markdown
-codehealthanalyzer dashboard .
+cha analyze .
+cha analyze . --format all --output reports
+cha violations . --format csv
+cha templates . --config cha_config.json
+cha errors . --no-json --format markdown
+cha dashboard .
 ```
 
 ### Python API
@@ -57,7 +59,7 @@ print(report["summary"]["quality_score"])
 
 ## Configuration
 
-Example `config.json`:
+Example `cha_config.json`:
 
 ```json
 {
@@ -76,14 +78,57 @@ Example `config.json`:
 }
 ```
 
-Supported fields:
+### Precedence order
 
-- `limits`: overrides size thresholds
-- `target_dir`: directory analyzed by Ruff
-- `templates_dir`: string or list of template directories
-- `exclude_dirs`: string or list of extra directories to ignore
-- `ruff_fix`: runs `ruff check --fix` before collection
-- `no_default_excludes`: disables the default exclude list
+- CLI flags (highest priority)
+- `--config` file
+- Library defaults
+
+### Supported fields
+
+| Field | Type | Default | What it controls |
+|---|---|---|---|
+| `limits` | object | internal thresholds | Size thresholds by structure/file type |
+| `target_dir` | string | `"."` | Target directory for code analysis (including Ruff) |
+| `templates_dir` | string or list | auto-detection | HTML/Jinja template directories to scan |
+| `exclude_dirs` | string or list | `[]` | Extra excludes beyond the default exclude list |
+| `ruff_fix` | boolean | `false` | Runs `ruff check --fix` before error collection |
+| `no_default_excludes` | boolean | `false` | Disables default excludes (`tests`, `venv`, `dist`, etc.) |
+
+### Quick config recipes
+
+Flask/Django project with templates in multiple directories:
+
+```json
+{
+  "templates_dir": ["templates", "app/templates", "src/templates"],
+  "exclude_dirs": ["migrations", "node_modules"]
+}
+```
+
+Monorepo (analyze a single service):
+
+```json
+{
+  "target_dir": "services/billing",
+  "templates_dir": ["services/billing/templates"]
+}
+```
+
+### Report detail control
+
+For `analyze`, full JSON is optional:
+
+- `--detail summary`: summary + domain files (`violations/templates/errors`)
+- `--detail standard` (default): same + `analysis_report.json`
+- `--detail full`: same + `full_report.json`
+
+Examples:
+
+```bash
+cha analyze . --config cha_config.json --detail summary
+cha analyze . --detail full --format all --output reports
+```
 
 ## Report contract
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -123,12 +123,26 @@ For `analyze`, full JSON is optional:
 - `--detail standard` (default): same + `analysis_report.json`
 - `--detail full`: same + `full_report.json`
 
+Generated files by mode:
+
+- `summary`: `summary_report.json`, `violations_report.json`, `templates_report.json`, `errors_report.json`
+- `standard`: everything from `summary` + `analysis_report.json`
+- `full`: everything from `standard` + `full_report.json`
+
 Examples:
 
 ```bash
 cha analyze . --config cha_config.json --detail summary
 cha analyze . --detail full --format all --output reports
 ```
+
+## Troubleshooting
+
+`Error: Invalid value for '--config' ... Path 'cha_config.json' does not exist`
+- Create the file in the current directory or pass an absolute path with `--config`.
+
+`WARNING: Ignoring invalid distribution ~odehealthanalyzer`
+- This usually means stale package metadata in `site-packages`; remove `~odehealthanalyzer*` directories.
 
 ## Report contract
 

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -51,12 +51,12 @@ Quick Start
 
 .. code-block:: bash
 
-   codehealthanalyzer analyze .
-   codehealthanalyzer analyze . --format all --output reports
-   codehealthanalyzer violations . --format csv
-   codehealthanalyzer templates . --config config.json
-   codehealthanalyzer errors . --no-json --format markdown
-   codehealthanalyzer dashboard .
+   cha analyze .
+   cha analyze . --format all --output reports
+   cha violations . --format csv
+   cha templates . --config cha_config.json
+   cha errors . --no-json --format markdown
+   cha dashboard .
 
 **Python API**
 
@@ -74,7 +74,7 @@ Quick Start
 Configuration
 -------------
 
-Example ``config.json``:
+Example ``cha_config.json``:
 
 .. code-block:: json
 
@@ -101,6 +101,12 @@ Supported fields:
 * ``exclude_dirs``: string or list of extra directories to ignore
 * ``ruff_fix``: runs ``ruff check --fix`` before collection
 * ``no_default_excludes``: disables the default exclusions
+
+Report detail modes for ``analyze``:
+
+* ``--detail summary``: generates ``summary_report.json`` + domain files
+* ``--detail standard``: adds ``analysis_report.json``
+* ``--detail full``: adds ``full_report.json``
 
 Report Contract
 ---------------

--- a/docs/en/installation.rst
+++ b/docs/en/installation.rst
@@ -1,6 +1,45 @@
 Installation
 ============
 
-For the current installation options, use the Portuguese reference below:
+Requirements
+------------
 
-* :doc:`../installation`
+* Python 3.8+
+* Ruff available in the environment for error analysis
+* Operating system: Windows, macOS, or Linux
+
+Install via pip
+---------------
+
+.. code-block:: bash
+
+   pip install codehealthanalyzer
+
+With dashboard support:
+
+.. code-block:: bash
+
+   pip install "codehealthanalyzer[web]"
+
+Development install
+-------------------
+
+.. code-block:: bash
+
+   git clone https://github.com/imparcialista/codehealthanalyzer.git
+   cd codehealthanalyzer
+   pip install -e ".[dev,web]"
+
+Validate installation
+---------------------
+
+.. code-block:: bash
+
+   cha --version
+   python -c "import codehealthanalyzer; print(codehealthanalyzer.__version__)"
+
+If you plan to run error analysis, also validate Ruff:
+
+.. code-block:: bash
+
+   ruff --version

--- a/docs/en/quickstart.rst
+++ b/docs/en/quickstart.rst
@@ -1,6 +1,61 @@
 Quick Start
 ===========
 
-For the current quick start guide, use the Portuguese reference below:
+First run
+---------
 
-* :doc:`../quickstart`
+After installation, run a simple analysis in your current project:
+
+.. code-block:: bash
+
+   cd /path/to/your/project
+   cha analyze .
+
+Core CLI commands
+-----------------
+
+.. code-block:: bash
+
+   cha analyze . --format all --output reports
+   cha score .
+   cha info .
+   cha violations . --format csv
+   cha templates . --config cha_config.json
+   cha errors . --no-json --format markdown
+   cha dashboard .
+
+Python API
+----------
+
+.. code-block:: python
+
+   from codehealthanalyzer import CodeAnalyzer
+
+   analyzer = CodeAnalyzer(
+       ".",
+       config={"target_dir": ".", "templates_dir": ["templates"]},
+   )
+   report = analyzer.generate_full_report(output_dir="reports")
+   print(report["summary"]["quality_score"])
+
+Report detail levels
+--------------------
+
+.. code-block:: bash
+
+   cha analyze . --detail summary
+   cha analyze . --detail standard
+   cha analyze . --detail full
+
+Generated files by level:
+
+* ``summary``: ``summary_report.json`` + domain files
+* ``standard``: ``summary`` + ``analysis_report.json``
+* ``full``: ``standard`` + ``full_report.json``
+
+Common error
+------------
+
+``Error: Invalid value for '--config' ... Path 'cha_config.json' does not exist``
+
+* Create ``cha_config.json`` in the current directory, or pass an absolute path.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,13 +52,13 @@ Uso Rápido
 .. code-block:: bash
 
    # Análise completa do projeto atual
-   codehealthanalyzer analyze .
+   cha analyze .
 
-   codehealthanalyzer analyze . --format all --output reports
-   codehealthanalyzer violations . --format csv
-   codehealthanalyzer templates . --config config.json
-   codehealthanalyzer errors . --no-json --format markdown
-   codehealthanalyzer dashboard .
+   cha analyze . --format all --output reports
+   cha violations . --format csv
+   cha templates . --config cha_config.json
+   cha errors . --no-json --format markdown
+   cha dashboard .
 
 **API Python**
 
@@ -76,7 +76,7 @@ Uso Rápido
 Configuração
 ------------
 
-Exemplo de ``config.json``:
+Exemplo de ``cha_config.json``:
 
 .. code-block:: json
 
@@ -103,6 +103,12 @@ Campos suportados:
 * ``exclude_dirs``: string ou lista de diretórios extras a ignorar
 * ``ruff_fix``: roda ``ruff check --fix`` antes da coleta
 * ``no_default_excludes``: desabilita as exclusões padrão
+
+Detalhamento de relatório no comando ``analyze``:
+
+* ``--detail summary``: gera ``summary_report.json`` + arquivos por domínio
+* ``--detail standard``: adiciona ``analysis_report.json``
+* ``--detail full``: adiciona ``full_report.json``
 
 Contrato de Relatório
 ---------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -56,7 +56,7 @@ Para verificar se a instalação foi bem-sucedida:
 
 .. code-block:: bash
 
-   codehealthanalyzer --version
+   cha --version
    # ou
    python -c "import codehealthanalyzer; print(codehealthanalyzer.__version__)"
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -12,7 +12,7 @@ Após a instalação, rode uma análise simples no diretório atual:
 .. code-block:: bash
 
    cd /caminho/para/seu/projeto
-   codehealthanalyzer analyze .
+   cha analyze .
 
 Comandos Básicos da CLI
 -----------------------
@@ -21,38 +21,38 @@ Comandos Básicos da CLI
 
 .. code-block:: bash
 
-   codehealthanalyzer analyze . --format all --output reports
+   cha analyze . --format all --output reports
 
 **Score de qualidade**
 
 .. code-block:: bash
 
-   codehealthanalyzer score .
+   cha score .
 
 **Informações do projeto**
 
 .. code-block:: bash
 
-   codehealthanalyzer info .
+   cha info .
 
 **Análises específicas**
 
 .. code-block:: bash
 
    # Apenas violações de tamanho
-   codehealthanalyzer violations . --format csv
+   cha violations . --format csv
 
    # Apenas templates HTML
-   codehealthanalyzer templates . --config config.json
+   cha templates . --config cha_config.json
 
    # Apenas erros de linting
-   codehealthanalyzer errors . --no-json --format markdown
+   cha errors . --no-json --format markdown
 
 **Dashboard**
 
 .. code-block:: bash
 
-   codehealthanalyzer dashboard .
+   cha dashboard .
 
 Uso da API Python
 -----------------
@@ -130,3 +130,10 @@ Próximos Passos
 2. Integre os comandos da CLI ao CI do projeto.
 3. Use os formatos HTML, Markdown e CSV conforme o público do relatório.
 4. Acople a API Python em scripts internos ou pipelines.
+
+Erros comuns
+------------
+
+``Error: Invalid value for '--config' ... Path 'cha_config.json' does not exist``
+
+* Crie o arquivo no diretório atual ou use caminho absoluto em ``--config``.


### PR DESCRIPTION
Prioritizes `cha` in documentation and CLI examples.

Changes:
- replace command examples from `codehealthanalyzer ...` to `cha ...`
- add explicit note that `cha` is the recommended short alias
- keep package/import name as `codehealthanalyzer`
- keep `cha_config.json` examples in both PT/EN READMEs