### PR TITLE
ci: automate tag creation from version bump + release 1.2.5

### DIFF
--- a/.github/workflows/auto-tag-from-version.yml
+++ b/.github/workflows/auto-tag-from-version.yml
@@ -1,0 +1,50 @@
+name: Auto Tag From Version
+
+on:
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - "codehealthanalyzer/version.py"
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Compute tag from package version
+        id: version
+        run: |
+          VERSION=$(python -c "from codehealthanalyzer.version import __version__; print(__version__)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: exists
+        run: |
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.exists.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"

--- a/codehealthanalyzer/version.py
+++ b/codehealthanalyzer/version.py
@@ -1,3 +1,3 @@
 """Versionamento central do pacote."""
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"


### PR DESCRIPTION
Automates release tagging and prepares next release version.

Changes:
- bump package version to `1.2.5`
- add workflow `.github/workflows/auto-tag-from-version.yml`
  - triggers on push to `master/main` when `codehealthanalyzer/version.py` changes
  - creates and pushes `v<version>` tag if it does not already exist

With existing `python-publish.yml` (triggered by `v*` tags), this makes PyPI publish automatic right after merge of a version bump PR.