### PR TITLE
chore: bump version to 1.2.6 (auto-publish test)

### DIFF
--- a/codehealthanalyzer/version.py
+++ b/codehealthanalyzer/version.py
@@ -1,3 +1,3 @@
 """Versionamento central do pacote."""
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"


### PR DESCRIPTION
Release bump to validate fully automatic publishing path.

- updates `codehealthanalyzer/version.py` to `1.2.6`
- after merge, `Auto Tag From Version` should:
  - create `v1.2.6`
  - build dist artifacts
  - publish to PyPI in the same workflow run